### PR TITLE
Exposed a Maven repository under the URL of the build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.417</version>
+        <version>1.466</version>
     </parent>
 
     <groupId>com.nirima.jenkins.repository</groupId>

--- a/repository-hpi/pom.xml
+++ b/repository-hpi/pom.xml
@@ -66,7 +66,7 @@
 
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
-            <version>1.417</version>
+            <version>1.466</version>
             <artifactId>maven-plugin</artifactId>
         </dependency>
 

--- a/repository-hpi/src/main/java/com/nirima/jenkins/RepositoryPlugin.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/RepositoryPlugin.java
@@ -24,7 +24,6 @@
 package com.nirima.jenkins;
 
 import com.nirima.jenkins.bridge.BridgeRepository;
-import com.nirima.jenkins.repo.RootElement;
 import com.nirima.jenkins.webdav.impl.MethodFactory;
 import com.nirima.jenkins.webdav.impl.ServletContextMimeTypeResolver;
 import com.nirima.jenkins.webdav.interfaces.IDavRepo;
@@ -36,9 +35,9 @@ import hudson.Plugin;
 import hudson.model.*;
 import hudson.util.IOUtils;
 import com.nirima.jenkins.repo.RepositoryContent;
-import com.nirima.jenkins.repo.project.ProjectsElement;
 import com.nirima.jenkins.repo.RepositoryDirectory;
 import com.nirima.jenkins.repo.RepositoryElement;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -102,9 +101,14 @@ public class RepositoryPlugin extends Plugin implements RootAction, Serializable
             return;
         }
 
+        serveRequest(new BridgeRepository(null), "/plugin/repository");
+    }
+
+    public void serveRequest(IDavRepo repo, String root) {
+        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerResponse rsp = Stapler.getCurrentResponse();
         try
         {
-            IDavRepo repo = new BridgeRepository(null);
             if (repo.getMimeTypeResolver() == null)
             {
                 ServletContextMimeTypeResolver ctx = new ServletContextMimeTypeResolver();
@@ -112,7 +116,7 @@ public class RepositoryPlugin extends Plugin implements RootAction, Serializable
                 repo.setMimeTypeResolver(ctx);
             }
             IMethod method = methodFactory.createMethod(req, rsp);
-            method.init(req, rsp, null, repo, "/plugin/repository");
+            method.init(req, rsp, null, repo, root);
             method.invoke();
         }
         catch (Exception e)
@@ -122,8 +126,6 @@ public class RepositoryPlugin extends Plugin implements RootAction, Serializable
             //s_logger.error(e.toString());
             throw new RuntimeException(e);
         }
-
-
     }
 
     private void displayElement(StaplerRequest req, StaplerResponse rsp, RepositoryElement currentItem) throws Exception {

--- a/repository-hpi/src/main/java/com/nirima/jenkins/TransientBuildActionFactoryImpl.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/TransientBuildActionFactoryImpl.java
@@ -1,0 +1,57 @@
+package com.nirima.jenkins;
+
+import com.nirima.jenkins.bridge.BridgeRepository;
+import com.nirima.jenkins.repo.build.ProjectBuildRepositoryRoot;
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.TransientBuildActionFactory;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Exposes a per-build repository under the URL of a build.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Extension
+public class TransientBuildActionFactoryImpl extends TransientBuildActionFactory {
+    @Inject
+    RepositoryPlugin plugin;
+
+    public Collection<? extends Action> createFor(AbstractBuild build) {
+        return Collections.singleton(new BuildActionImpl(build));
+    }
+
+    public class BuildActionImpl implements Action {
+        private final AbstractBuild build;
+
+        public BuildActionImpl(AbstractBuild build) {
+            this.build = build;
+        }
+
+        public String getIconFileName() {
+            return plugin.getIconFileName();
+        }
+
+        public String getDisplayName() {
+            return "Build Artifacts As Maven Repository";
+        }
+
+        public String getUrlName() {
+            return "maven-repository";
+        }
+
+        public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+            plugin.serveRequest(
+                    new BridgeRepository(new ProjectBuildRepositoryRoot(null, build, build.getFullDisplayName()), null),
+                    req.findAncestor(this).getUrl());
+        }
+    }
+}

--- a/repository-hpi/src/main/java/com/nirima/jenkins/bridge/BridgeRepository.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/bridge/BridgeRepository.java
@@ -38,10 +38,16 @@ public class BridgeRepository implements IDavRepo {
     private static final Logger log = Logger.getLogger(BridgeRepository.class);
 
     IMimeTypeResolver mimeTypeResolver;
-    RootElement rootElement = new RootElement();
+    RepositoryDirectory rootElement;
 
     public BridgeRepository(IMimeTypeResolver mimeTypeResolver)
     {
+        this(new RootElement(),mimeTypeResolver);
+    }
+
+    public BridgeRepository(RepositoryDirectory root, IMimeTypeResolver mimeTypeResolver)
+    {
+        this.rootElement = root;
         this.mimeTypeResolver = mimeTypeResolver;
     }
 


### PR DESCRIPTION
This makes it easier to access the Maven repository from a build, and generally make the URL strucure more consistent with the rest of Jenkins. Concrete benefits include taking advantages of permalinks (and thus other plugins that produce permalinks, such as the promoted builds plugin.)

The `TransientBuildActionFactory` extension point was introduced in 1.459, but in that version it is broken. 1.466 was picked as the base version because it's the release used for LTS.

I also wonder if you'd be interested in co-hosting this repository in the Jenkins org, like all the other plugins.
