### PR TITLE
Fixed a build problem induced by my previous change.

### DIFF
--- a/repository-hpi/pom.xml
+++ b/repository-hpi/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
-                <version>1.3</version>
+                <version>1.4</version>
                 <executions>
 
                     <execution>
@@ -54,6 +54,18 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                    <version>1.8.6</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                    <version>1.8.3</version>
+                  </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -94,6 +106,12 @@
             <artifactId>jenkins-maven-plugin</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
ClassNotFoundError: MojoNotFoundException was because Maven decided to
pick up 2.0 of maven-plugin-api (which is specified in
jenkins-maven-plugin), over 3.0 of maven-plugin-api (which is specified
in the core) because the former is shorter from the root.

I then had a Groovy <-> GMaven version issue. I fixed this by defining
Groovy as a dependency in gmaven plugin. IIRC, GMaven plugin relies on
the project to have a compile/runtime dependency on Groovy, and when
that doesn't have the right version it dies with NoSuchMethodError.

And finally GMaven complained about missing Ant, so that was added too.
