### PR TITLE
Index out of bound error

### DIFF
--- a/repository-hpi/src/main/java/com/nirima/jenkins/webdav/impl/methods/MethodBase.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/webdav/impl/methods/MethodBase.java
@@ -104,8 +104,7 @@ public class MethodBase implements IMethod {
         m_baseUrl += root;
 
         // PathInfo will also be /config/woo, but we ignore the 1st part
-        m_path = request.getPathInfo();
-
+        m_path = request.getContextPath() + request.getPathInfo();
         if (m_path == null) {
             m_path = "/";
         } else {


### PR DESCRIPTION
Method getPathInfo() does not contains context path, but method getUrl() of instance of Ancestor contains context path. If there is some context path the method substring() throws java.lang.StringIndexOutOfBoundsException. so I add context path into attribut m_path.
